### PR TITLE
modify node installed path in src/gradleps.js

### DIFF
--- a/src/gradleps.js
+++ b/src/gradleps.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 var program = require('commander');
 var colors = require('colors');


### PR DESCRIPTION
Hey! This is good tools I just survey. But when I installed it on my Mac and type `gradle`, some error appeared:

```
 ~/Desktop -->gradleps
-bash: /Users/veck/.nvm/v0.10.35/bin/gradleps: /usr/bin/node: bad interpreter: No such file or directory
```

But it works fine on my Ubuntu.

I think this may be caused by the node path you wrote in src/gradleps.js: `#!/usr/bin/node`, it should more proper to be `#!/usr/bin/env node`. I tried it, then my Mac work fine and Ubuntu still work properly.
